### PR TITLE
fix install with new suite name oldoldstable

### DIFF
--- a/Debian/8/preseed.cfg
+++ b/Debian/8/preseed.cfg
@@ -93,7 +93,7 @@ d-i mirror/http/hostname string archive.kernel.org
 d-i mirror/http/directory string /debian-archive/debian
 d-i mirror/http/proxy string
 d-i mirror/http/mirror select archive.kernel.org
-d-i mirror/suite string jessie
+d-i mirror/suite string oldoldstable
 d-i mirror/codename string jessie
 ##################################################
 


### PR DESCRIPTION
This fixes the repo cannot be found issue, when installing